### PR TITLE
Fixed a bug in Unix timestamp generation

### DIFF
--- a/Client/ServiceClient.cs
+++ b/Client/ServiceClient.cs
@@ -66,7 +66,7 @@ namespace GatecoinServiceInterface.Client
 
         private static double ToUnixTimeStamp(DateTime date)
         {
-            return (date.ToUniversalTime() - UnixEpoch).TotalSeconds;
+            return Math.Round((date.ToUniversalTime() - UnixEpoch).TotalSeconds);
         }
 
         private Action<HttpWebRequest> requestFilter;


### PR DESCRIPTION
Without the Math.round() you get digits after the decimal point  and the authentication to the API is impossible.