### PR TITLE
Private channels

### DIFF
--- a/Client/ServiceSignature.cs
+++ b/Client/ServiceSignature.cs
@@ -45,7 +45,7 @@ namespace GatecoinServiceInterface.Client
                                    ), secret);
         }
 
-        private static string CreateToken(string message, string secret)
+        public static string CreateToken(string message, string secret)
         {
             // don't allow null secrets
             secret = secret ?? "";

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Events are defined by the following DTO data types:
 * TickerDto
 * MarketDepthDto
 
+For a description of each DTO and the fields they include please refer to our [Official API and Streaming documentation](https://gatecoin.com/api/).
+
 To subscribe to all events, the ```SubscribeAll``` method should be invoked.<br>
 To ***unsubscribe*** from all events the ```Dispose``` method should be invoked.
  

--- a/WebSocket/Client/AccessToken.cs
+++ b/WebSocket/Client/AccessToken.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace GatecoinServiceInterface.WebSocket.Client
+{
+    /// <summary>
+    /// AccessToken passed with header parameters
+    /// </summary>
+    public class AccessToken
+    {
+        /// <summary>
+        /// Public Key
+        /// </summary>
+        public string PublicKey { get; set; }
+
+        /// <summary>
+        /// Encrypted Message
+        /// </summary>
+        public string SignedMessage { get; set; }
+
+        /// <summary>
+        /// RequestDate
+        /// </summary>
+        public DateTime DateTime { get; set; }
+    }
+}

--- a/WebSocket/Client/Channels.cs
+++ b/WebSocket/Client/Channels.cs
@@ -6,31 +6,50 @@ namespace GatecoinServiceInterface.WebSocket.Client
 {
     internal static class Channels
     {
-        public const string Trade = "trade";
-        public const string MarketDepth = "marketdepth";
-        public const string Ticker = "ticker";
-        private static readonly Dictionary<Type, string> TypeMapping;
+        public const string Trade = "public/trade";
+        public const string TradePrivate = "private/trade";
+        public const string MarketDepth = "public/marketdepth";
+        public const string Ticker = "public/ticker";
+        private static readonly Dictionary<Type, string> PublicTypeMapping;
+        private static readonly Dictionary<Type, string> PrivateTypeMapping;
 
         static Channels()
         {
-            TypeMapping = new Dictionary<Type, string>
-                          {
-                              [typeof(MarketDepthDto)] = MarketDepth,
-                              [typeof(TradeDto)] = Trade,
-                              [typeof(TickerDto)] = Ticker
-                          };
+            PublicTypeMapping = new Dictionary<Type, string>
+            {
+                [typeof(MarketDepthDto)] = MarketDepth,
+                [typeof(TradeDto)] = Trade,
+                [typeof(TickerDto)] = Ticker
+            };
+
+            PrivateTypeMapping = new Dictionary<Type, string>
+            {
+                [typeof(TradeDto)] = TradePrivate
+            };
         }
 
         public static string GetChannelHub<TDto>()
         {
             var type = typeof(TDto);
 
-            if (!TypeMapping.ContainsKey(type))
+            if (!PublicTypeMapping.ContainsKey(type))
             {
                 throw new NotSupportedException($"The model type '{type}' is not supported");
             }
 
-            return $"/v1/hub/{TypeMapping[type]}";
+            return $"/v1/hub/{PublicTypeMapping[type]}";
+        }
+
+        public static string GetPrivateChannelHub<TDto>()
+        {
+            var type = typeof(TDto);
+
+            if (!PrivateTypeMapping.ContainsKey(type))
+            {
+                throw new NotSupportedException($"The model type '{type}' is not supported");
+            }
+
+            return $"/v1/hub/{PrivateTypeMapping[type]}";
         }
     }
 }

--- a/WebSocket/Client/DateTimeExtensions.cs
+++ b/WebSocket/Client/DateTimeExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Globalization;
+
+namespace GatecoinServiceInterface.WebSocket.Client
+{
+    internal static class Unix
+    {
+        public static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    }
+
+    internal static class DateTimeExtensions
+    {
+        public static string ToUnixTimeString(this DateTime? dateTime)
+        {
+            return dateTime.ToUnixTime().ToString("F0", CultureInfo.InvariantCulture);
+        }
+
+        public static string ToUnixTimeString(this DateTime dateTime)
+        {
+            return dateTime.ToUnixTime().ToString("F0", CultureInfo.InvariantCulture);
+        }
+
+        public static double ToUnixTime(this DateTime? dateTime)
+        {
+            if (dateTime == null)
+            {
+                return 0;
+            }
+
+            return dateTime.Value.TotalSeconds();
+        }
+
+        public static double ToUnixTime(this DateTime dateTime)
+        {
+            return dateTime.TotalSeconds();
+        }
+
+        private static double TotalSeconds(this DateTime dateTime)
+        {
+            return (dateTime.ToUniversalTime() - Unix.Epoch).TotalSeconds;
+        }
+    }
+}

--- a/WebSocket/Client/DisconnectEventArgs.cs
+++ b/WebSocket/Client/DisconnectEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace GatecoinServiceInterface.WebSocket.Client
+{
+    public class DisconnectEventArgs<TDto> : EventArgs
+    {
+        public DisconnectEventArgs(IStreamingClient<TDto> client, Exception exception)
+        {
+            Client = client;
+            Exception = exception;
+        }
+
+        public Exception Exception { get; }
+        public IStreamingClient<TDto> Client { get; }
+    }
+}

--- a/WebSocket/Client/IStreamingClient.cs
+++ b/WebSocket/Client/IStreamingClient.cs
@@ -9,8 +9,17 @@ namespace GatecoinServiceInterface.WebSocket.Client
         /// <summary>
         /// Starts connection
         /// </summary>
+        /// <returns>Returns the current IStreamingClient instance</returns>
         [PublicAPI]
         Task<IStreamingClient<TDto>> Start();
+
+        /// <summary>
+        /// Stop the connection
+        /// </summary>
+        /// <returns>Returns the current IStreamingClient instance</returns>
+        [PublicAPI]
+        [Pure]
+        Task<IStreamingClient<TDto>> Stop();
 
         /// <summary>
         /// Registers a handler that will be invoked with all events.
@@ -31,5 +40,10 @@ namespace GatecoinServiceInterface.WebSocket.Client
         [PublicAPI]
         [Pure]
         IDisposable Subscribe([NotNull] string currencyPair, [NotNull] Action<TDto> handler);
+
+        /// <summary>
+        /// Event that will be triggered when the connection ends.
+        /// </summary>
+        event EventHandler<DisconnectEventArgs<TDto>> Disconnected;
     }
 }

--- a/WebSocket/Client/StreamingClient.cs
+++ b/WebSocket/Client/StreamingClient.cs
@@ -11,12 +11,17 @@ namespace GatecoinServiceInterface.WebSocket.Client
 {
     internal sealed class StreamingClient<TDto> : IStreamingClient<TDto>
     {
+        private const string ApiPublicKey = "API_PUBLIC_KEY";
+        private const string ApiRequestSignature = "API_REQUEST_SIGNATURE";
+        private const string ApiRequestDate = "API_REQUEST_DATE";
+
         private readonly HubConnection _connection;
         private readonly HttpMessageHandler _httpMessageHandler;
         private readonly ILogger _logger;
 
         internal StreamingClient(
             string url,
+            AccessToken token = null,
             HttpMessageHandler httpMessageHandler = null,
             ILoggerFactory loggerFactory = null)
         {
@@ -31,23 +36,38 @@ namespace GatecoinServiceInterface.WebSocket.Client
 
             url = url.TrimEnd('/');
 
-            var urlHub = $"{url}{Channels.GetChannelHub<TDto>()}";
+            if (token != null && !IsTokenValid(token))
+            {
+                throw new ArgumentException("If AccessToken is passed as a parameter, all the fields should be valid");
+            }
+
+            var urlHub = token != null ? $"{url}{Channels.GetPrivateChannelHub<TDto>()}" : $"{url}{Channels.GetChannelHub<TDto>()}";
 
             _connection = new HubConnectionBuilder()
                 .WithUrl(
                     urlHub,
                     options =>
                     {
-                        if (httpMessageHandler == null)
+                        if (httpMessageHandler != null)
                         {
-                            return;
+                            options.HttpMessageHandlerFactory = _ => httpMessageHandler;
                         }
 
-                        options.HttpMessageHandlerFactory = _ => httpMessageHandler;
+                        if (token != null)
+                        {
+                            options.Headers.Add(ApiPublicKey, token.PublicKey);
+                            options.Headers.Add(ApiRequestSignature, token.SignedMessage);
+                            options.Headers.Add(ApiRequestDate, token.DateTime.ToUnixTimeString());
+                        }
                     })
                 .AddJsonProtocol()
                 .Build();
+
+            _connection.Closed += OnConnectionOnClosed;
+
         }
+        
+        public event EventHandler<DisconnectEventArgs<TDto>> Disconnected;
 
         [Pure]
         [PublicAPI]
@@ -107,12 +127,43 @@ namespace GatecoinServiceInterface.WebSocket.Client
             return this;
         }
 
+        [Pure]
+        [PublicAPI]
+        public async Task<IStreamingClient<TDto>> Stop()
+        {
+            await _connection.StopAsync();
+            return this;
+        }
+
         public void Dispose()
         {
-            // TODO: I don't like this, but in the time scope we need to put it off
             _connection?.StopAsync().Wait();
             _connection?.DisposeAsync().Wait();
             _httpMessageHandler?.Dispose();
+        }
+
+        private static bool IsTokenValid(AccessToken token)
+        {
+            return
+                !string.IsNullOrWhiteSpace(token.PublicKey) &&
+                !string.IsNullOrWhiteSpace(token.SignedMessage) &&
+                token.DateTime != default(DateTime);
+        }
+
+        private Task OnConnectionOnClosed(Exception error)
+        {
+            _logger.LogWarning("Connection closed {error}", error?.Message ?? "by the user.");
+
+            OnDisconnected(new DisconnectEventArgs<TDto>(this, error));
+
+            return Task.CompletedTask;
+        }
+
+        private void OnDisconnected(DisconnectEventArgs<TDto> e)
+        {
+            var handler = Disconnected;
+
+            handler?.Invoke(this, e);
         }
     }
 }

--- a/WebSocket/Client/StreamingClientBuilder.cs
+++ b/WebSocket/Client/StreamingClientBuilder.cs
@@ -10,6 +10,7 @@ namespace GatecoinServiceInterface.WebSocket.Client
         private readonly string _url;
         private HttpMessageHandler _httpMessageHandler;
         private ILoggerFactory _loggerFactory;
+        private AccessToken _token;
 
         public StreamingClientBuilder(string url)
         {
@@ -25,6 +26,7 @@ namespace GatecoinServiceInterface.WebSocket.Client
         {
             return new StreamingClient<TDto>(
                     _url,
+                    _token,
                     _httpMessageHandler,
                     _loggerFactory);
         }
@@ -40,6 +42,19 @@ namespace GatecoinServiceInterface.WebSocket.Client
         public StreamingClientBuilder WithLoggerFactory(ILoggerFactory loggerFactory)
         {
             _loggerFactory = loggerFactory;
+            return this;
+        }
+
+        [PublicAPI]
+        public StreamingClientBuilder WithAccessToken(Action<AccessToken> tokenFactory)
+        {
+            if (tokenFactory == null)
+            {
+                throw new ArgumentException(nameof(tokenFactory));
+            }
+
+            _token = new AccessToken();
+            tokenFactory(_token);
             return this;
         }
     }

--- a/WebSocket/Sample/DateTimeExtensions.cs
+++ b/WebSocket/Sample/DateTimeExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Globalization;
+using GatecoinServiceInterface.WebSocket.Client;
+
+namespace GatecoinServiceInterface.WebSocket.Sample
+{
+    /// <summary>
+    /// This extension and conversion is used in Streaming
+    /// </summary>
+    public static class DateTimeExtensions
+    {
+        public static string ToUnixTimeString(this DateTime? dateTime)
+        {
+            return dateTime.ToUnixTime().ToString("F0", CultureInfo.InvariantCulture);
+        }
+
+        public static string ToUnixTimeString(this DateTime dateTime)
+        {
+            return dateTime.ToUnixTime().ToString("F0", CultureInfo.InvariantCulture);
+        }
+
+        public static double ToUnixTime(this DateTime? dateTime)
+        {
+            if (dateTime == null)
+            {
+                return 0;
+            }
+
+            return dateTime.Value.TotalSeconds();
+        }
+
+        public static double ToUnixTime(this DateTime dateTime)
+        {
+            return dateTime.TotalSeconds();
+        }
+
+        private static double TotalSeconds(this DateTime dateTime)
+        {
+            return (dateTime.ToUniversalTime() - Unix.Epoch).TotalSeconds;
+        }
+    }
+}

--- a/WebSocket/Sample/Run.cs
+++ b/WebSocket/Sample/Run.cs
@@ -1,29 +1,133 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
+using GatecoinServiceInterface.Client;
 using GatecoinServiceInterface.WebSocket.Client;
 using GatecoinServiceInterface.WebSocket.Model;
 using Newtonsoft.Json;
 
 namespace GatecoinServiceInterface.WebSocket.Sample
 {
-    public class Run
+    public static class Run
     {
-        public static async Task Start()
+        public static string Root = "https://streaming.gtcprojects.com";
+        public static string PublicKey = "<PUBLIC-KEY-HERE>";
+        public static string PrivateKey = "<PRIVATE-KEY-HERE>";
+
+        private static string CurrencyPair = "BTCUSD";
+        private static readonly object LockObject = new object();
+
+        public static void RunAll()
         {
-            var builder = new StreamingClientBuilder("put url here");
+            var tasks = new List<Task>();
 
-            using (var client = await builder.BuildTraderClient().Start())
+            tasks.Add(Run.StartPublicStreamingForTrader());
+
+            tasks.Add(Run.StartPrivateStreamingForTrader(PublicKey, PrivateKey));
+
+            Task.WaitAll(tasks.ToArray());
+
+            WriteLine(ConsoleColor.White, "Finished. Press enter to exit");
+            Console.ReadLine();
+        }
+
+        public static async Task StartPublicStreamingForTrader()
+        {
+            var builder = new StreamingClientBuilder(Root);
+
+            using (var client = builder.BuildTraderClient())
+            using(client.SubscribeAll(PublicTradeBroadcastHandler))
+            using(client.Subscribe(CurrencyPair, PublicTradeCurrencyPairHandler))
             {
-                void TradeHandler(TradeDto arg) => Console.WriteLine(JsonConvert.SerializeObject(arg));
+                client.Disconnected += OnClientOnDisconnected;
 
-                var subscription = client.SubscribeAll(TradeHandler);
-                var subscriptionBtcUsd = client.Subscribe("BTCUSD", TradeHandler);
+                await client.Start();
+                
+                WriteLine(ConsoleColor.White, "Waiting for public events for 1 minute");
 
-                Console.WriteLine("Waiting for events");
-                Console.ReadLine();
+                Thread.Sleep(60000);
+                
+                await client.Stop();
 
-                subscription.Dispose();
-                subscriptionBtcUsd.Dispose();
+                WriteLine(ConsoleColor.White, "Stop listening public events");
+            }
+        }
+
+        public static async Task StartPrivateStreamingForTrader(string publicKey, string privateKey)
+        {
+            var urlHub = $"{Root}{Channels.GetPrivateChannelHub<TradeDto>()}";
+            var timeStamp = DateTime.UtcNow;
+
+            var builder = new StreamingClientBuilder(Root);
+
+            builder
+                .WithAccessToken(
+                    token =>
+                    {
+                        token.DateTime = timeStamp;
+                        token.SignedMessage = ServiceSignature.CreateToken($"{urlHub}{timeStamp.ToUnixTimeString()}", privateKey);
+                        token.PublicKey = publicKey;
+                    });
+
+
+            using (var client = builder.BuildTraderClient())
+            using (client.SubscribeAll(PrivateTradeBroadcastHandler))
+            using (client.Subscribe(CurrencyPair, PrivateTradeCurrencyPairHandler))
+            {
+                client.Disconnected += OnClientOnDisconnected;
+
+                await client.Start();
+
+                WriteLine(ConsoleColor.Blue, "Waiting for private events for 2 minute");
+
+                Thread.Sleep(120000);
+                
+                await client.Stop();
+
+                WriteLine(ConsoleColor.Blue, "Stop private public events");
+            }
+        }
+
+        private static void OnClientOnDisconnected(object sender, DisconnectEventArgs<TradeDto> args)
+        {
+            if (args.Exception != null)
+            {
+                WriteLine(ConsoleColor.Red, $"Disconected. Error: {args.Exception.Message}");
+                WriteLine(ConsoleColor.Red, "Trying to reconnect after 15 seconds...");
+
+                Thread.Sleep(15000);
+
+                try
+                {
+                    args.Client.Start();
+                    WriteLine(ConsoleColor.Red, "Connected.");
+                }
+                catch (Exception ex)
+                {
+                    WriteLine(ConsoleColor.Red, $"Was not able to connect. {ex.Message}");
+                }
+            }
+            else
+            {
+                WriteLine(ConsoleColor.Red, $"Disconected by the user.");
+            }
+        }
+
+        private static void PublicTradeBroadcastHandler(TradeDto arg) => WriteLine(ConsoleColor.Green, $"Public Trade Broadcast Channel: {JsonConvert.SerializeObject(arg)}");
+        private static void PublicTradeCurrencyPairHandler(TradeDto arg) => WriteLine(ConsoleColor.Green, $"Public Trade CurrencyPair Channel: {JsonConvert.SerializeObject(arg)}");
+
+        private static void PrivateTradeBroadcastHandler(TradeDto arg) => WriteLine(ConsoleColor.DarkMagenta, $"Private Trade Broadcast Channel: {JsonConvert.SerializeObject(arg)}");
+        private static void PrivateTradeCurrencyPairHandler(TradeDto arg) => WriteLine(ConsoleColor.DarkMagenta, $"Private Trade CurrencyPair Channel: {JsonConvert.SerializeObject(arg)}");
+
+        private static void WriteLine(ConsoleColor color, string format)
+        {
+            lock (LockObject)
+            {
+                var before = Console.ForegroundColor;
+                Console.ForegroundColor = color;
+                Console.WriteLine(format);
+                Console.ForegroundColor = before;
             }
         }
     }


### PR DESCRIPTION
Including Private Channel clients implementation for Streaming Channel.

Following changes:

- Public hubs changed to include the prefix _public/_
- Including the Trade private channel as _private/trade_
- If the user provides the authentication token when he is creating the client, it will create a Private Channel client, otherwise, it will create a Public Channel client.
- Created an example how to connect to public and private trade channel to listen to the broadcast and BTCUSD currency pair.

After the client is built, there are the following methods:

- **SubscribeAll** - register for broadcast channel
- **Subscribe** - register for a specific currency pair
- **Start** - Start to listen to the channel
- **Stop** - Stop to listen to the channel

And the event:

- **Disconnected** - that will fire when the client is disconnected from the channel. It receives as parameter one exception, that contains the error related to the disconnection. If the exception is null means that the user disconnect from the channel.